### PR TITLE
Update squeeze_pro.py

### DIFF
--- a/pandas_ta/momentum/squeeze_pro.py
+++ b/pandas_ta/momentum/squeeze_pro.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from numpy import NaN as npNaN
+from numpy import nan as npNaN
 from pandas import DataFrame
 from pandas_ta.momentum import mom
 from pandas_ta.overlap import ema, sma


### PR DESCRIPTION
The error message ImportError: cannot import name 'NaN' from 'numpy' indicates that the pandas_ta library is trying to import NaN from numpy, but it's not finding it there. This is likely due to a compatibility issue between pandas_ta and the installed version of NumPy. NaN (Not a Number) is typically accessed as np.nan in NumPy, not as a direct import from numpy import NaN. It seems that pandas_ta might be using an outdated import statement.